### PR TITLE
Fix: prevent rendering '0' when no stock suggestions are available

### DIFF
--- a/frontend/src/components/Selection.tsx
+++ b/frontend/src/components/Selection.tsx
@@ -150,7 +150,7 @@ function Selection() {
                 </CardContent>
                 </Card>
             </div>
-                {suggestions.length && displaySuggestions()}
+            {suggestions.length > 0 ? displaySuggestions() : null}
         </div>
         :
         selectedValue && <div className="flex justify-center items-center">


### PR DESCRIPTION
Resolves #1

## Description

Fixes a bug in `Selection.tsx` where the UI was incorrectly displaying a "0" when no stock suggestions were returned. This was due to improper conditional rendering. The component now checks for the length of the suggestions array before rendering the suggestion section, ensuring that nothing is displayed when results are empty.

## Demo
![Screenshot from 2025-05-14 15-43-34](https://github.com/user-attachments/assets/46d27c45-7631-427c-bb92-60e55fca5805)


